### PR TITLE
use pytz instead of datetime.timezone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "mysql-connector-python>=8.0.18,<8.0.24 ; python_version<'3.6'",
     "mysql-connector-python>=8.0.18,<8.0.30 ; python_version>='3.6'",
     "pytimeparse>=1.1.8",
+    "pytz>=2023.3",
     "six>=1.12.0",
     "simplejson>=3.16.0",
     "tqdm>=4.35.0",

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,6 +13,7 @@ pytest-faker ; python_version<"3.0"
 pytest-mock
 pytest-timeout
 pytimeparse>=1.1.8
+pytz>=2023.3
 simplejson>=3.16.0
 six>=1.12.0
 sqlalchemy>=1.3.7,<1.4.0 ; python_version<"3.0"

--- a/sqlite3_to_mysql/sqlite_utils.py
+++ b/sqlite3_to_mysql/sqlite_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from sys import version_info
 
@@ -10,6 +10,7 @@ import six
 from pytimeparse.timeparse import timeparse
 from unidecode import unidecode
 from packaging import version
+import pytz as timezone
 
 if version_info.major == 3 and 4 <= version_info.minor <= 6:
     from backports.datetime_fromisoformat import MonkeyPatch  # pylint: disable=E0401
@@ -67,6 +68,7 @@ def convert_date(value):
             "DATE field contains Invalid isoformat string: {}".format(err)
         )
 
+
 def check_sqlite_table_xinfo_support(version_string):
     """Check for SQLite table_xinfo support."""
     sqlite_version = version.parse(version_string)
@@ -76,9 +78,10 @@ def check_sqlite_table_xinfo_support(version_string):
         return True
     return False
 
+
 def convert_epoch(value):
-  """Convert unix epoch time to datetime."""
-  _intval = int(value)
-  if _intval >= pow(2,31):  #convert 64 bit epoch date to 32 bit
-      return datetime.fromtimestamp(int(_intval / 1000), timezone.utc)
-  return datetime.fromtimestamp(_intval, timezone.utc)
+    """Convert unix epoch time to datetime."""
+    _intval = int(value)
+    if _intval >= pow(2, 31):  # convert 64 bit epoch date to 32 bit
+        return datetime.fromtimestamp(int(_intval / 1000), timezone.utc)
+    return datetime.fromtimestamp(_intval, timezone.utc)


### PR DESCRIPTION
This will fix the Python 2 incompatibility.

There are still errors though, because the adapter does not check if the data actually is a UNIX timestamp or a string representation of time, i.e. `2023-05-31 14:24:55.00000`